### PR TITLE
Fix wrong label count when multiple labels are not assigned to products

### DIFF
--- a/src/Spryker/Zed/ProductLabelGui/Communication/Table/ProductLabelTable.php
+++ b/src/Spryker/Zed/ProductLabelGui/Communication/Table/ProductLabelTable.php
@@ -226,7 +226,7 @@ class ProductLabelTable extends AbstractTable
                     sprintf('COUNT(%s)', SpyProductLabelProductAbstractTableMap::COL_FK_PRODUCT_ABSTRACT),
                     static::COL_ABSTRACT_PRODUCT_RELATION_COUNT,
                 )
-                ->groupByFkProductLabel()
+            ->addGroupByColumn(SpyProductLabelTableMap::COL_ID_PRODUCT_LABEL)
             ->endUse();
     }
 


### PR DESCRIPTION
## PR Description

When multiple product labels exist, that are not assigned to any products, the label count is wrong. This results in labels not displayed in the table at all or the pagination not showing the correct number of pages.

The behaviour is caused by the wrong column being used for the group by in `\Spryker\Zed\ProductLabelGui\Communication\Table\ProductLabelTable::addAbstractProductRelationCountToQuery`.
Using a right side column for `group by` in a `LEFT JOIN` will result in all left side rows not matching the join criteria grouped together as a single row.
Using the left side primary key instead of the join tables foreign key will preserve the correct label count.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
